### PR TITLE
fix for wrong compression returning NaN

### DIFF
--- a/src/range/Range1D.ts
+++ b/src/range/Range1D.ts
@@ -63,8 +63,8 @@ export default class Range1D {
         r.push(RangeElem.single(indices[start]));
       } else {
         //+1 since end is excluded
-        //fix while just +1 -1 is allowed
-        if (Math.abs(deltas[start]) === 1) {
+        //fix while just +1 is allowed and -1 is not allowed
+        if (deltas[start] === 1) {
           r.push(RangeElem.range(indices[start], indices[act - 1] + deltas[start], deltas[start]));
         } else {
           for (i = start; i < act; i++) {


### PR DESCRIPTION
If the indices are [..., 1, 0, ...] the compression created a RangeElem with `from:1, to:-1, step:-1`. `to` must be >0 otherwise asList() will return NaN for the element. The fix skips -1 and include 0.