### PR TITLE
switched fetching of IDTypes and setting filledUp to true

### DIFF
--- a/src/idtype/manager.ts
+++ b/src/idtype/manager.ts
@@ -75,8 +75,8 @@ export async function listAll(): Promise<IIDType[]> {
   if (filledUp) {
     return Promise.resolve(list());
   }
-  filledUp = true;
   const c = await <Promise<IIDType[]>>getAPIJSON('/idtype', {}, []);
+  filledUp = true;
   fillUpData(c);
   return list();
 }


### PR DESCRIPTION
I switched the two lines, because when trying to get the IDTypes in a loop leads to empty IDType arrays, when the request has not yet finished (and therefore they are not in the cache yet although filledUp is already true)

closes Caleydo/targid_boehringer#493