### PR TITLE
Sgratzl/migrate provenance graph

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -136,7 +136,7 @@ export class EventHandler implements IEventHandler {
   static readonly MULTI_EVENT_SEPARATOR = ',';
   private readonly handlers = new Map<string, SingleEventHandler>();
 
-  private readonly propgationHandler: IEventListener = (event: IEvent) => {
+  private readonly propagationHandler: IEventListener = (event: IEvent) => {
     if (!event.isPropagationStopped()) {
       this.fireEvent(propagateEvent(event, this));
     }
@@ -228,11 +228,11 @@ export class EventHandler implements IEventHandler {
    * @param events
    */
   propagate(progatee: IEventHandler, ...events: string[]) {
-    progatee.on(events.join(EventHandler.MULTI_EVENT_SEPARATOR), this.propgationHandler);
+    progatee.on(events.join(EventHandler.MULTI_EVENT_SEPARATOR), this.propagationHandler);
   }
 
   stopPropagation(progatee: IEventHandler, ...events: string[]) {
-    progatee.off(events.join(EventHandler.MULTI_EVENT_SEPARATOR), this.propgationHandler);
+    progatee.off(events.join(EventHandler.MULTI_EVENT_SEPARATOR), this.propagationHandler);
   }
 }
 

--- a/src/event.ts
+++ b/src/event.ts
@@ -136,6 +136,12 @@ export class EventHandler implements IEventHandler {
   static readonly MULTI_EVENT_SEPARATOR = ',';
   private readonly handlers = new Map<string, SingleEventHandler>();
 
+  private readonly propgationHandler: IEventListener = (event: IEvent) => {
+    if (!event.isPropagationStopped()) {
+      this.fireEvent(propagateEvent(event, this));
+    }
+  }
+
   /**
    * register a global event handler
    * @param events either one event string (multiple are supported using , as separator) or a map of event handlers
@@ -222,11 +228,11 @@ export class EventHandler implements IEventHandler {
    * @param events
    */
   propagate(progatee: IEventHandler, ...events: string[]) {
-    progatee.on(events.join(EventHandler.MULTI_EVENT_SEPARATOR), (event: IEvent) => {
-      if (!event.isPropagationStopped()) {
-        this.fireEvent(propagateEvent(event, this));
-      }
-    });
+    progatee.on(events.join(EventHandler.MULTI_EVENT_SEPARATOR), this.propgationHandler);
+  }
+
+  stopPropagation(progatee: IEventHandler, ...events: string[]) {
+    progatee.off(events.join(EventHandler.MULTI_EVENT_SEPARATOR), this.propgationHandler);
   }
 }
 

--- a/src/graph/GraphBase.ts
+++ b/src/graph/GraphBase.ts
@@ -4,8 +4,8 @@
 /**
  * Created by Samuel Gratzl on 22.10.2014.
  */
-import {IDataDescription} from '../datatype';
-import {GraphNode, GraphEdge, AGraph, IGraph} from './graph';
+import {GraphNode, GraphEdge, AGraph, IGraph, IGraphDataDescription} from './graph';
+export {IGraphDataDescription} from './graph';
 
 export interface IGraphFactory {
   makeNode(p: any): GraphNode;
@@ -16,25 +16,6 @@ export const defaultGraphFactory: IGraphFactory = {
   makeNode: (p: any) => ((new GraphNode()).restore(p)),
   makeEdge: (p: any, lookup) => ((new GraphEdge()).restore(p, lookup))
 };
-
-export interface IGraphDataDescription extends IDataDescription {
-  /**
-   * size: [number of nodes, number of edges]
-   */
-  readonly size: [number, number];
-
-  /**
-   * where to store: memory, remote, local, session, given (requires instance)
-   */
-  readonly storage?: string;
-
-  /**
-   * in case of storage type 'given'
-   */
-  readonly graph?: AGraph;
-
-  readonly attrs: {[key: string]: any};
-}
 
 export default class GraphBase extends AGraph implements IGraph {
   private readonly _nodes: GraphNode[];

--- a/src/graph/GraphBase.ts
+++ b/src/graph/GraphBase.ts
@@ -54,6 +54,17 @@ export default class GraphBase extends AGraph implements IGraph {
     return this._edges;
   }
 
+  /**
+   * migrate one graph to another cleaning this graph returning node references
+   * @returns {{nodes: GraphNode[]; edges: GraphEdge[]}}
+   */
+  migrate(): Promise<{nodes: GraphNode[], edges: GraphEdge[]}>|{nodes: GraphNode[], edges: GraphEdge[]} {
+    return {
+      nodes: this.nodes,
+      edges: this.edges
+    };
+  }
+
   addNode(n: GraphNode): this|Promise<this> {
     this.nodes.push(n);
     this.fire('add_node', n);

--- a/src/graph/LocalStorageGraph.ts
+++ b/src/graph/LocalStorageGraph.ts
@@ -5,10 +5,10 @@
  * Created by Samuel Gratzl on 22.10.2014.
  */
 import {IEvent} from '../event';
-import AGraph, {IGraphFactory, IGraphDataDescription} from './GraphBase';
+import GraphBase, {IGraphFactory, IGraphDataDescription} from './GraphBase';
 import {GraphEdge, GraphNode, IGraph} from './graph';
 
-export default class LocalStorageGraph extends AGraph implements IGraph {
+export default class LocalStorageGraph extends GraphBase implements IGraph {
 
   private updateHandler = (event: IEvent) => {
     const s = event.target;
@@ -22,6 +22,33 @@ export default class LocalStorageGraph extends AGraph implements IGraph {
 
   constructor(desc: IGraphDataDescription, nodes: GraphNode[] = [], edges: GraphEdge[] = [], private storage: Storage = sessionStorage) {
     super(desc, nodes, edges);
+
+    if (nodes.length > 0 || edges.length > 0) {
+      const uid = this.uid;
+      this.storage.setItem(`${uid}.nodes`, JSON.stringify(nodes.map((d) => d.id)));
+      nodes.forEach((n) => {
+        this.storage.setItem(uid + '.node.' + n.id, JSON.stringify(n.persist()));
+        n.on('setAttr', this.updateHandler);
+      });
+
+      this.storage.setItem(`${uid}.edges`, JSON.stringify(edges.map((d) => d.id)));
+      edges.forEach((e) => {
+        this.storage.setItem(`${uid}.edge.${e.id}`, JSON.stringify(e.persist()));
+        e.on('setAttr', this.updateHandler);
+      });
+    }
+  }
+
+  static migrate(graph: GraphBase, storage = sessionStorage) {
+    return Promise.resolve(graph.migrate()).then(({nodes, edges}) => {
+      return new LocalStorageGraph(graph.desc, nodes, edges, storage);
+    });
+  }
+
+  migrate() {
+    this.nodes.forEach((n) => n.off('setAttr', this.updateHandler));
+    this.edges.forEach((n) => n.off('setAttr', this.updateHandler));
+    return super.migrate();
   }
 
   static load(desc: IGraphDataDescription, factory: IGraphFactory, storage: Storage = sessionStorage, reset = false) {
@@ -32,7 +59,7 @@ export default class LocalStorageGraph extends AGraph implements IGraph {
     return r;
   }
 
-  static clone(graph: AGraph, factory: IGraphFactory, storage: Storage = sessionStorage) {
+  static clone(graph: GraphBase, factory: IGraphFactory, storage: Storage = sessionStorage) {
     const r = new LocalStorageGraph(graph.desc, [], [], storage);
     r.restoreDump(graph.persist(), factory);
     return r;

--- a/src/graph/RemoteStorageGraph.ts
+++ b/src/graph/RemoteStorageGraph.ts
@@ -147,7 +147,7 @@ export default class RemoteStoreGraph extends GraphBase {
     return this.sendQueued();
   }
 
-  async addAll(nodes: GraphNode[], edges: GraphEdge[]) {
+  addAll(nodes: GraphNode[], edges: GraphEdge[]) {
     //add all and and to queue
     nodes.forEach((n) => {
       super.addNode(n);

--- a/src/graph/RemoteStorageGraph.ts
+++ b/src/graph/RemoteStorageGraph.ts
@@ -4,7 +4,7 @@
 import {sendAPI} from '../ajax';
 import {IEvent} from '../event';
 import GraphBase, {IGraphFactory, IGraphDataDescription} from './GraphBase';
-import {GraphEdge, GraphNode} from './graph';
+import {GraphEdge, GraphNode, IGraph} from './graph';
 
 interface ISyncItem {
   type: 'node'|'edge';
@@ -35,11 +35,17 @@ export default class RemoteStoreGraph extends GraphBase {
   private readonly queue: ISyncItem[] = [];
   private flushTimeout: number = -1;
 
-  constructor(desc: IGraphDataDescription, nodes: GraphNode[] = [], edges: GraphEdge[] = []) {
-    super(desc, nodes, edges);
+  constructor(desc: IGraphDataDescription) {
+    super(desc);
     this.batchSize = desc.attrs.batchSize || RemoteStoreGraph.DEFAULT_BATCH_SIZE;
   }
 
+  migrate() {
+    this.nodes.forEach((n) => n.off('setAttr', this.updateHandler));
+    this.edges.forEach((n) => n.off('setAttr', this.updateHandler));
+    //TODO delete old
+    return super.migrate();
+  }
   static load(desc: IGraphDataDescription, factory: IGraphFactory) {
     const r = new RemoteStoreGraph(desc);
     return r.load(factory);
@@ -130,6 +136,7 @@ export default class RemoteStoreGraph extends GraphBase {
     this.fire(`sync_start`, ++this.waitForSynced, 'batch');
     return sendAPI(`/dataset/${this.desc.id}`, { desc: param }, 'POST').then(() => {
       this.fire(`sync`, --this.waitForSynced, 'batch');
+      return this;
     });
   }
 
@@ -139,6 +146,22 @@ export default class RemoteStoreGraph extends GraphBase {
     }
     return this.sendQueued();
   }
+
+  async addAll(nodes: GraphNode[], edges: GraphEdge[]) {
+    //add all and and to queue
+    nodes.forEach((n) => {
+      super.addNode(n);
+      n.on('setAttr', this.updateHandler);
+      this.queue.push({type: 'node', op: 'add', id: n.id, desc: n.persist()});
+    });
+    edges.forEach((e) => {
+      super.addEdge(e);
+      e.on('setAttr', this.updateHandler);
+      this.queue.push({type: 'edge', op: 'add', id: e.id, desc: e.persist()});
+    });
+    return this.sendQueued();
+  }
+
 
   async addNode(n: GraphNode): Promise<this> {
     super.addNode(n);

--- a/src/graph/graph.ts
+++ b/src/graph/graph.ts
@@ -8,8 +8,7 @@ import {SelectOperation, resolve as idtypes_resolve, SelectAble} from '../idtype
 import {all, parse, RangeLike, list} from '../range';
 import {IPersistable, flagId, uniqueId} from '../index';
 import {EventHandler} from '../event';
-import {IDataType} from '../datatype';
-import {IGraphDataDescription} from 'phovea_core/src/graph/GraphBase';
+import {IDataType, IDataDescription} from '../datatype';
 
 export const DIM_NODES = 0;
 export const IDTYPE_NODES = '_nodes';
@@ -157,6 +156,25 @@ export function isType(type: string|RegExp) {
   return (edge: GraphEdge) => type instanceof RegExp ? type.test(edge.type) : edge.type === type;
 }
 
+
+export interface IGraphDataDescription extends IDataDescription {
+  /**
+   * size: [number of nodes, number of edges]
+   */
+  readonly size: [number, number];
+
+  /**
+   * where to store: memory, remote, local, session, given (requires instance)
+   */
+  readonly storage?: string;
+
+  /**
+   * in case of storage type 'given'
+   */
+  readonly graph?: AGraph;
+
+  readonly attrs: {[key: string]: any};
+}
 
 export interface IGraph extends IDataType {
   readonly desc: IGraphDataDescription;

--- a/src/graph/graph.ts
+++ b/src/graph/graph.ts
@@ -9,6 +9,7 @@ import {all, parse, RangeLike, list} from '../range';
 import {IPersistable, flagId, uniqueId} from '../index';
 import {EventHandler} from '../event';
 import {IDataType} from '../datatype';
+import {IGraphDataDescription} from 'phovea_core/src/graph/GraphBase';
 
 export const DIM_NODES = 0;
 export const IDTYPE_NODES = '_nodes';
@@ -158,6 +159,8 @@ export function isType(type: string|RegExp) {
 
 
 export interface IGraph extends IDataType {
+  readonly desc: IGraphDataDescription;
+
   readonly nodes: GraphNode[];
   readonly nnodes: number;
   readonly edges: GraphEdge[];

--- a/src/provenance/MixedStorageProvenanceGraphManager.ts
+++ b/src/provenance/MixedStorageProvenanceGraphManager.ts
@@ -28,7 +28,7 @@ export default class MixedStorageProvenanceGraphManager implements IProvenanceGr
   }
 
   delete(desc: IProvenanceGraphDataDescription): Promise<boolean> {
-    if ((<any>desc).local) {
+    if (desc.local) {
       return this.local.delete(desc);
     } else {
       return this.remote.delete(desc);
@@ -66,6 +66,10 @@ export default class MixedStorageProvenanceGraphManager implements IProvenanceGr
 
   async cloneRemote(desc: IProvenanceGraphDataDescription, extras: any = {}): Promise<ProvenanceGraph> {
     return this.remote.clone(await this.getGraph(desc), extras);
+  }
+
+  migrateRemote(graph: ProvenanceGraph, extras: any = {}): Promise<ProvenanceGraph> {
+    return this.remote.migrate(graph, extras);
   }
 
   importLocal(json: any, desc: any = {}) {

--- a/src/provenance/RemoteStorageProvenanceGraphManager.ts
+++ b/src/provenance/RemoteStorageProvenanceGraphManager.ts
@@ -68,10 +68,13 @@ export default class RemoteStorageProvenanceGraphManager implements IProvenanceG
 
   async migrate(graph: ProvenanceGraph, desc: any = {}) {
     return this.importImpl({nodes: [], edges: []}, desc).then((backend: RemoteStoreGraph) => {
-      return Promise.resolve(graph.backend.migrate()).then(({nodes, edges}) => backend.addAll(nodes, edges)).then(() => {
-        graph.migrateBackend(backend);
-        return graph;
-      });
+      return Promise.resolve(graph.backend.migrate())
+        .then(({nodes, edges}) => {
+          return backend.addAll(nodes, edges);
+        }).then(() => {
+          graph.migrateBackend(backend);
+          return graph;
+        });
     });
   }
 

--- a/src/provenance/RemoteStorageProvenanceGraphManager.ts
+++ b/src/provenance/RemoteStorageProvenanceGraphManager.ts
@@ -10,8 +10,8 @@ import ProvenanceGraph, {
 } from './ProvenanceGraph';
 import GraphBase from '../graph/GraphBase';
 import {currentUserNameOrAnonymous} from '../security';
-import GraphProxy from 'phovea_core/src/graph/GraphProxy';
-import RemoteStoreGraph from 'phovea_core/src/graph/RemoteStorageGraph';
+import GraphProxy from '../graph/GraphProxy';
+import RemoteStoreGraph from '../graph/RemoteStorageGraph';
 
 export default class RemoteStorageProvenanceGraphManager implements IProvenanceGraphManager {
   private options = {
@@ -66,7 +66,7 @@ export default class RemoteStorageProvenanceGraphManager implements IProvenanceG
     });
   }
 
-  async migrate(graph: ProvenanceGraph, desc: any = {}) {
+  async migrate(graph: ProvenanceGraph, desc: any = {}): Promise<ProvenanceGraph> {
     return this.importImpl({nodes: [], edges: []}, desc).then((backend: RemoteStoreGraph) => {
       return Promise.resolve(graph.backend.migrate())
         .then(({nodes, edges}) => {

--- a/src/provenance/RemoteStorageProvenanceGraphManager.ts
+++ b/src/provenance/RemoteStorageProvenanceGraphManager.ts
@@ -38,7 +38,7 @@ export default class RemoteStorageProvenanceGraphManager implements IProvenanceG
     return removeData(desc);
   }
 
-  async clone(graph: GraphBase, desc: any = {}): Promise<ProvenanceGraph> {
+  clone(graph: GraphBase, desc: any = {}): Promise<ProvenanceGraph> {
     return this.import(graph.persist(), desc);
   }
 
@@ -66,7 +66,7 @@ export default class RemoteStorageProvenanceGraphManager implements IProvenanceG
     });
   }
 
-  async migrate(graph: ProvenanceGraph, desc: any = {}): Promise<ProvenanceGraph> {
+  migrate(graph: ProvenanceGraph, desc: any = {}): Promise<ProvenanceGraph> {
     return this.importImpl({nodes: [], edges: []}, desc).then((backend: RemoteStoreGraph) => {
       return Promise.resolve(graph.backend.migrate())
         .then(({nodes, edges}) => {


### PR DESCRIPTION
option to migrate a temporary provenance graph to a persistent one without replaying