### PR TITLE
restrict whatwg-streams to typescript 2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "tslib": "1.9.0",
+    "@types/whatwg-streams": "0.0.4",
     "@types/whatwg-fetch": "0.0.33",
     "@types/handlebars": "4.0.33"
   },


### PR DESCRIPTION
At the moment at datavisyn we cannot build with the requirement of typescript 2.3 introduced by `@types/whatwg-streams@0.0.5`.

A quick solution to this problem is to restrict `@types/whatwg-streams` to version 0.0.4 where the typescript 2.2 version is used.

In the near future we at datavisyn will upgrade to 2.7, but not before the initial release of one of our customers that is scheduled for next week.