### PR TITLE
Add extension points on login and logout

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,0 +1,10 @@
+/**
+ * Triggered when a user got logged in
+ */
+export const PHOVEA_LOGIN = 'phoveaLogin';
+
+/**
+ * Triggered when a user got logged out
+ */
+export const PHOVEA_LOGOUT = 'phoveaLogout';
+

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,7 +1,7 @@
 /**
  * Triggered when a user was logged in
  *
- * @factoryParam {User} user The user object that was logged in
+ * @factoryParam {IUser} user The user object that was logged in
  */
 export const EP_PHOVEA_CORE_LOGIN = 'epPhoveaCoreLogin';
 

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,10 +1,12 @@
 /**
- * Triggered when a user got logged in
+ * Triggered when a user was logged in
+ *
+ * @factoryParam {User} user The user object that was logged in
  */
-export const PHOVEA_LOGIN = 'phoveaLogin';
+export const EP_PHOVEA_CORE_LOGIN = 'epPhoveaCoreLogin';
 
 /**
- * Triggered when a user got logged out
+ * Triggered when a user was logged out. Does not provide any further information.
  */
-export const PHOVEA_LOGOUT = 'phoveaLogout';
+export const EP_PHOVEA_CORE_LOGOUT = 'epPhoveaCoreLogout';
 

--- a/src/security.ts
+++ b/src/security.ts
@@ -6,7 +6,7 @@
 import {retrieve, store, remove} from './session';
 import {fire} from './event';
 import {list} from './plugin';
-import {PHOVEA_LOGIN, PHOVEA_LOGOUT} from './extensions';
+import {EP_PHOVEA_CORE_LOGIN, EP_PHOVEA_CORE_LOGOUT} from './extensions';
 
 export const GLOBAL_EVENT_USER_LOGGED_IN = 'USER_LOGGED_IN';
 export const GLOBAL_EVENT_USER_LOGGED_OUT = 'USER_LOGGED_OUT';
@@ -50,7 +50,7 @@ export function login(user: IUser) {
   store('username', user.name);
   store('user', user);
 
-  list(PHOVEA_LOGIN).map((desc) => {
+  list(EP_PHOVEA_CORE_LOGIN).map((desc) => {
     desc.load().then((plugin) => plugin.factory(user));
   });
 
@@ -64,7 +64,7 @@ export function logout() {
   const wasLoggedIn = isLoggedIn();
   reset();
   if (wasLoggedIn) {
-    list(PHOVEA_LOGOUT).map((desc) => {
+    list(EP_PHOVEA_CORE_LOGOUT).map((desc) => {
       desc.load().then((plugin) => plugin.factory());
     });
 

--- a/src/security.ts
+++ b/src/security.ts
@@ -5,6 +5,8 @@
 
 import {retrieve, store, remove} from './session';
 import {fire} from './event';
+import {list} from './plugin';
+import {PHOVEA_LOGIN, PHOVEA_LOGOUT} from './extensions';
 
 export const GLOBAL_EVENT_USER_LOGGED_IN = 'USER_LOGGED_IN';
 export const GLOBAL_EVENT_USER_LOGGED_OUT = 'USER_LOGGED_OUT';
@@ -47,6 +49,11 @@ export function login(user: IUser) {
   store('logged_in', true);
   store('username', user.name);
   store('user', user);
+
+  list(PHOVEA_LOGIN).map((desc) => {
+    desc.load().then((plugin) => plugin.factory(user));
+  });
+
   fire(GLOBAL_EVENT_USER_LOGGED_IN, user);
 }
 
@@ -57,6 +64,10 @@ export function logout() {
   const wasLoggedIn = isLoggedIn();
   reset();
   if (wasLoggedIn) {
+    list(PHOVEA_LOGOUT).map((desc) => {
+      desc.load().then((plugin) => plugin.factory());
+    });
+
     fire(GLOBAL_EVENT_USER_LOGGED_OUT);
   }
 }


### PR DESCRIPTION
Closes #146

## Changes

* Add two new extension points when the user is logged in `phoveaLogin` and logged out `phoveaLogout`

## Usage



_plugin_repo/phovea.js_
```js
module.exports = function (registry) {
  registry.push('epPhoveaCoreLogin', 'yourExtensionName', function () {
    return import('./src/loginPanel');
  }, {
    'factory': 'trackLogin'
  });

  registry.push('epPhoveaCoreLogout', 'yourExtensionName', function () {
    return import('./src/loginPanel');
  }, {
    'factory': 'trackLogout'
  });
};
```

**OR**

_plugin_repo/src/phovea.ts_
```ts
import {IRegistry} from 'phovea_core/src/plugin';
import {EP_PHOVEA_CORE_LOGIN, EP_PHOVEA_CORE_LOGOUT} from 'phovea_core/src/extensions';

export default function (registry: IRegistry) {
  registry.push(EP_PHOVEA_CORE_LOGIN, 'yourExtensionName', () => System.import('./loginPanel'), {
    factory: 'trackLogin'
  });

  registry.push(EP_PHOVEA_CORE_LOGOUT, 'yourExtensionName', () => System.import('./loginPanel'), {
    factory: 'trackLogout'
  });
}
```

_plugin_repo/src/loginPanel.ts_
```ts
import {IUser} from 'phovea_core/src/security';

/**
 * Login extension point
 */
export function trackLogin(user: IUser) {
  console.log('user logged in', user.name);
}

/**
 * Logout extension point
 */
export function trackLogout() {
  console.log('user logged out');
}
```
