### PR TITLE
Change css filename from `style` to `[name]` in webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -280,7 +280,7 @@ function generateWebpack(options) {
   if (!options.bundle || options.isApp) {
     // extract the included css file to own file
     const p = new ExtractTextPlugin({
-      filename: (options.isApp || options.moduleBundle ? 'style' : pkg.name) + (options.min && !options.nosuffix ? '.min' : '') + '.css',
+      filename: (options.isApp || options.moduleBundle ? '[name]' : pkg.name) + (options.min && !options.nosuffix ? '.min' : '') + '.css',
       allChunks: true // there seems to be a bug in dynamically loaded chunk styles are not loaded, workaround: extract all styles from all chunks
     });
     base.plugins.push(p);


### PR DESCRIPTION
Amendment to PR #161 

### Summary

- Change css filename from `style` to `[name]` in webpack.config.js