### PR TITLE
Initialize a new instance of i18next instead of the default i18n…

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -6,6 +6,13 @@ const DEFAULT_LANGUAGE = 'en';
 const DEFAULT_NAMESPACE = 'default_namespace';
 
 /**
+ * Create a unique i18next instance
+ * Thus allowing the existence of multiple i18next instances with different configurations
+ * without one overwriting the other
+ */
+const i18n = i18next.createInstance();
+
+/**
  *  Awaits the translation files registered at the EP_PHOVEA_CORE_LOCALE extension point
  *  Initialize I18next with the translation files
  */
@@ -21,7 +28,7 @@ export async function initI18n() {
     });
   }));
 
-  return i18next
+  return i18n
     .use({
       type: 'postProcessor',
       name: 'showKeyDebugger',
@@ -50,9 +57,8 @@ export async function initI18n() {
          overwrites the others
       */
       plugins.sort((pluginA, pluginB) => pluginA.order - pluginB.order).forEach((plugin) => {
-        i18next.addResourceBundle(plugin.lng, plugin.ns, plugin.resources, true, true);
+        i18n.addResourceBundle(plugin.lng, plugin.ns, plugin.resources, true, true);
       });
     });
 }
-
-export default i18next;
+export default i18n;


### PR DESCRIPTION

Closes phovea/phovea_core#170

### Summary

- Created a new instance of i18next  instead of initializing the default i18next instance
- Now it is possible to have multiple instances of i18next ( as long as you name them differently )
without them overwriting one another.