### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,13 +47,10 @@
     "release:minor": "npm version minor && npm publish && git push --follow-tags",
     "release:patch": "npm version patch && npm publish && git push --follow-tags",
     "predist": "npm run build && npm run docs",
-    "dist": "mkdirp dist && cd build && tar cvzf ../dist/phovea_core.tar.gz *"
+    "dist": "mkdir dist && cd build && tar cvzf ../dist/phovea_core.tar.gz *"
   },
   "dependencies": {
-    "i18next": "^17.0.18",
-    "@types/whatwg-streams": "0.0.4",
-    "@types/whatwg-fetch": "0.0.33",
-    "@types/handlebars": "4.0.33"
+    "i18next": "^19.3.2"
   },
   "devDependencies": {
     "@types/jasmine": "2.5.47",
@@ -63,7 +60,7 @@
     "extract-loader": "0.1.0",
     "extract-text-webpack-plugin": "2.1.0",
     "file-loader": "0.11.1",
-    "fork-ts-checker-webpack-plugin": "0.4.1",
+    "fork-ts-checker-webpack-plugin": "0.4.4",
     "html-loader": "0.4.5",
     "ifdef-loader": "2.0.0",
     "imports-loader": "0.7.1",
@@ -76,8 +73,7 @@
     "karma-junit-reporter": "2.0.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "2.0.3",
-    "mkdirp": "^1.0.3",
-    "node-sass": "^4.12.0",
+    "node-sass": "^4.13.1",
     "null-loader": "0.1.1",
     "raw-loader": "0.5.1",
     "sass-loader": "6.0.7",
@@ -86,7 +82,7 @@
     "ts-loader": "4.0.1",
     "tslib": "~1.11.0",
     "tslint": "5.9.1",
-    "typedoc": "~0.16.9",
+    "typedoc": "~0.16.10",
     "typescript": "~3.8.2",
     "url-loader": "0.5.8",
     "webpack": "2.3.3",

--- a/src/ajax.ts
+++ b/src/ajax.ts
@@ -3,8 +3,6 @@
  * Copyright (c) The Caleydo Team. All rights reserved.
  * Licensed under the new BSD license, available at http://caleydo.org/license
  **************************************************************************** */
-// to resolve the window extensions
-/// <reference types="whatwg-fetch" />
 
 /**
  * Created by Samuel Gratzl on 04.08.2014.


### PR DESCRIPTION
Closes #181 

### Summary
* remove unused dependencies (`@types/whatwg-streams`, `@types/whatwg-fetch`, `` and `@types/handlebars`)
* remove `mkdirp` as it would only be needed for recursion
* update `fork-ts-checker-webpack-plugin` since the formerly used version required Typescript 2 as peerDependency and therefore caused errors
* update `i18next`